### PR TITLE
Enable more SC QAM Upstreams than 9

### DIFF
--- a/custom_components/arris_cm3500/ArrisCM3500ModemDashboard.py
+++ b/custom_components/arris_cm3500/ArrisCM3500ModemDashboard.py
@@ -73,7 +73,7 @@ create_properties(
 create_properties(
     ArrisCM3500ModemDashboard,
     "ucid",
-    range(1, 9),
+    range(1, 13),
     ["Frequency", "Power", "Channel_Type", "Symbol_Rate", "Modulation"],
     lambda self, ucid, key: self.get_value(self.upstream_qam_lookup, ucid, key),
 )


### PR DESCRIPTION
After Vodafone did maintenance work in my segment my SC QAM upstream channel IDs change to IDs > 8